### PR TITLE
Ipstr conversion

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.21-bullseye",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [4195]
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/config/pbfuncs_3.yaml
+++ b/config/pbfuncs_3.yaml
@@ -1,0 +1,19 @@
+input:
+  file:
+    paths: [ ./data/input.txt ]
+    codec: lines
+
+pipeline:
+  threads: 1
+  processors:
+  - sleep:
+      duration: 1s
+  - bloblang: |
+      # root = this
+      root.more_stuff = ipv4str_as_bytes("200.128.0.65")
+
+output:
+  label: "plain"
+  file:
+    path: ./data/data.out # No default (required)
+    codec: lines

--- a/main.go
+++ b/main.go
@@ -14,11 +14,11 @@ import (
 	// _ "github.com/benthosdev/benthos/v4/public/components/all"
 
 	// Add your plugin packages here
-	_ "github.com/benthosdev/benthos-plugin-example/bloblang"
-	_ "github.com/benthosdev/benthos-plugin-example/cache"
-	_ "github.com/benthosdev/benthos-plugin-example/input"
-	_ "github.com/benthosdev/benthos-plugin-example/output"
-	_ "github.com/benthosdev/benthos-plugin-example/processor"
+	_ "github.com/benthosdev/benthos-plugin-example/pbfuncs"
+	// _ "github.com/benthosdev/benthos-plugin-example/cache"
+	// _ "github.com/benthosdev/benthos-plugin-example/input"
+	// _ "github.com/benthosdev/benthos-plugin-example/output"
+	// _ "github.com/benthosdev/benthos-plugin-example/processor"
 )
 
 func main() {

--- a/pbfuncs/package.go
+++ b/pbfuncs/package.go
@@ -1,0 +1,29 @@
+package pbfuncs
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/benthosdev/benthos/v4/public/bloblang"
+)
+
+func init() {
+	ipv4StrAsBytesSpec := bloblang.NewPluginSpec().
+		Param(bloblang.NewStringParam("key"))
+
+	err := bloblang.RegisterFunctionV2("ipv4str_as_bytes", ipv4StrAsBytesSpec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
+		key, err := args.GetString("key")
+		if err != nil {
+			return nil, err
+		}
+
+		return func() (interface{}, error) {
+			// Convert IP Address string to bytes
+			possibleIP := net.IP.To4(net.ParseIP(key))
+			return fmt.Sprintf("%c%c%c%c", possibleIP[0], possibleIP[1], possibleIP[2], possibleIP[3]), nil
+		}, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pbfuncs/package.go
+++ b/pbfuncs/package.go
@@ -1,7 +1,7 @@
 package pbfuncs
 
 import (
-	"fmt"
+	b64 "encoding/base64"
 	"net"
 
 	"github.com/benthosdev/benthos/v4/public/bloblang"
@@ -9,8 +9,9 @@ import (
 
 func init() {
 	ipv4StrAsBytesSpec := bloblang.NewPluginSpec().
-		Param(bloblang.NewStringParam("key"))
-
+		Param(bloblang.NewStringParam("key")).
+		Description(`Returns an IPv4 address string as a 4 byte value similar to inet_aton.`).
+		Example("", `root.srcip = ipv4str_as_bytes("65.66.67.68")`)
 	err := bloblang.RegisterFunctionV2("ipv4str_as_bytes", ipv4StrAsBytesSpec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		key, err := args.GetString("key")
 		if err != nil {
@@ -20,7 +21,8 @@ func init() {
 		return func() (interface{}, error) {
 			// Convert IP Address string to bytes
 			possibleIP := net.IP.To4(net.ParseIP(key))
-			return fmt.Sprintf("%c%c%c%c", possibleIP[0], possibleIP[1], possibleIP[2], possibleIP[3]), nil
+			ipBase64Enc := b64.StdEncoding.EncodeToString([]byte(possibleIP))
+			return ipBase64Enc, nil
 		}, nil
 	})
 	if err != nil {


### PR DESCRIPTION
Adds bloblang function ipv4str_as_bytes to convert an IPv4 address in string format to 4 octets encoded in base64.
This base64 value can then be used by the protobuf processor to produce the correct bytes array.
example bloblang:
root.ip_addr = ipv4str_as_bytes("65.66.67.68")